### PR TITLE
Customize Makefile variables: CXX and CXXFlags can be set outside.

### DIFF
--- a/marlin/Makefile
+++ b/marlin/Makefile
@@ -1,3 +1,6 @@
+CXX      ?= g++
+CXXFLAGS ?= -std=c++11 -Wall -g -O3
+
 # 1.2: need to make sure opt.o goes in the right order to get the right scope on the command-line arguments
 # Use this for Linux
 files=$(subst .cc,.o,$(shell /bin/ls basic/*.cc))
@@ -5,10 +8,10 @@ files=$(subst .cc,.o,$(shell /bin/ls basic/*.cc))
 all: marlin_cluster
 
 marlin_cluster: marlin_cluster.o $(files)
-	g++ -std=c++11 -Wall -g -O3 -o marlin_cluster marlin_cluster.o $(files)
+	$(CXX) $(CXXFLAGS) -o marlin_cluster marlin_cluster.o $(files)
 
 %.o: %.cc
-	g++ -Wunused -std=c++11 -Wall -g -O3 -o $@ -c $<
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	rm -rf marlin_cluster basic/*.o *.o


### PR DESCRIPTION
With this PR `CXX` and `CXXFlags` can be set outside, e.g. setting another compiler or additional compile flags. Now it's possible to use:

```bash
CXX=/usr/bin/clang++ CXXFLAGS="-std=c++11 -Ofast -Wall" make
```

to compile the clustering tool.