### PR TITLE
add support for conllu format --conllu-format

### DIFF
--- a/marmot/src/marmot/core/SimpleTagger.java
+++ b/marmot/src/marmot/core/SimpleTagger.java
@@ -21,6 +21,7 @@ public class SimpleTagger implements Tagger {
 	private Model model_;
 	private WeightVector weight_vector_;
 	private int num_level_;
+	private int format_ = 0; // 1 for conllu
 
 	private double[][] threshs_;
 	private double[] candidates_per_state_;
@@ -588,6 +589,15 @@ public class SimpleTagger implements Tagger {
 		}
 
 		return list;
+	}
+
+	public void setFormat(String format) {
+		if(format == "conllu") {
+			format_ = 1;	
+		}
+	}
+	public int getFormat() {
+		return format_;
 	}
 
 	protected List<int[]> tag_(Sequence sequence) {

--- a/marmot/src/marmot/morph/MorphOptions.java
+++ b/marmot/src/marmot/morph/MorphOptions.java
@@ -53,6 +53,7 @@ public class MorphOptions extends Options {
 	public static final String LEMMA_TAG_DEPENDENT = "lemma-tag-dependent";
 	public static final String LEMMA_LEMMING_GENERATOR = "lemma-use-lemming-generator";
 	public static final String RESTRICT_POS_TAGS_TO_SEEN_COMBINATIONS = "restrict-pos-tags-to-seen-combinations";
+	public static final String OUTPUT_FORMAT_CONLLU = "conllu-format" ; 
 
 	private static final Map<String, String> DEFALUT_VALUES_ = new HashMap<String, String>();
 	private static final Map<String, String> COMMENTS_ = new HashMap<String, String>();
@@ -140,6 +141,8 @@ public class MorphOptions extends Options {
 		COMMENTS_.put(LEMMA_LEMMING_GENERATOR, "Passed to lemma model.");
 		DEFALUT_VALUES_.put(RESTRICT_POS_TAGS_TO_SEEN_COMBINATIONS, "false");
 		COMMENTS_.put(RESTRICT_POS_TAGS_TO_SEEN_COMBINATIONS, "Restrict the possible pos tags of a word to the combinations seen in the training set.");
+		DEFALUT_VALUES_.put(OUTPUT_FORMAT_CONLLU, "false");
+		COMMENTS_.put(OUTPUT_FORMAT_CONLLU, "Use CoNLL-U output format.");
 
 	}
 
@@ -235,6 +238,10 @@ public class MorphOptions extends Options {
 		}
 		
 		return prop;
+	}
+
+	public boolean getFormatIsCoNLLU() {
+		return Boolean.parseBoolean(getProperty(OUTPUT_FORMAT_CONLLU));
 	}
 
 	public int getNumFolds() {

--- a/marmot/src/marmot/morph/Sentence.java
+++ b/marmot/src/marmot/morph/Sentence.java
@@ -6,6 +6,7 @@ package marmot.morph;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Hashtable;
 
 import marmot.core.Sequence;
 import marmot.core.Token;
@@ -16,6 +17,9 @@ public class Sentence extends AbstractList<Token> implements Sequence {
 
 	private static final long serialVersionUID = 1L;
 	private List<Word> tokens_;
+	private List<String> comments_;
+	private Hashtable<Integer, String> segments_;
+	private Hashtable<Integer, String> empty_nodes_;
 
 	public Sentence(List<Word> tokens) {
 		tokens_ = new ArrayList<Word>(tokens);
@@ -29,6 +33,30 @@ public class Sentence extends AbstractList<Token> implements Sequence {
 	@Override
 	public int size() {
 		return tokens_.size();
+	}
+
+	public void setEmptyNodes(Hashtable<Integer, String> e) {
+		empty_nodes_ = e; 
+	}
+
+	public Hashtable<Integer, String> getEmptyNodes() {
+		return empty_nodes_;
+	}
+
+	public void setSegments(Hashtable<Integer, String> s) {
+		segments_ = s; 
+	}
+
+	public Hashtable<Integer, String> getSegments() {
+		return segments_;
+	}
+
+	public void setComments(List<String> c) {
+		comments_ = c; 
+	}
+
+	public List<String> getComments() {
+		return comments_;
 	}
 
 	public void setTags(List<String> tags) {

--- a/marmot/src/marmot/morph/io/SentenceReader.java
+++ b/marmot/src/marmot/morph/io/SentenceReader.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Hashtable;
 
 import marmot.core.Sequence;
 import marmot.morph.Sentence;
@@ -47,11 +48,34 @@ public class SentenceReader implements Iterable<Sequence> {
 				}
 
 				List<Word> tokens = new LinkedList<Word>();
+				List<String> comments = new LinkedList<String>();
+				Hashtable<Integer, String> segments = new Hashtable<Integer, String>();
+				Hashtable<Integer, String> empty_nodes = new Hashtable<Integer, String>();
 
 				while (line_iterator_.hasNext()) {
 					List<String> row = line_iterator_.next();
 					if (row.isEmpty()) {
 						break;
+					}
+					if (row.get(0).charAt(0) == '#') { // Comment
+						comments.add(row.get(0)); 
+						continue;
+					}
+					if (row.get(0).charAt(0) == '|') { // Segment
+						String segline = row.get(0);
+						String[] splittok = segline.split("\\|\\$\\|");
+						//System.err.println(segline);
+						//System.err.println(splittok[0]);
+						//System.err.println(splittok[1]);
+						//System.err.println(splittok[2]);
+						segments.put(Integer.parseInt(splittok[1]), splittok[2]);
+						continue;
+					}
+					if (row.get(0).charAt(0) == '$') { // Empty node
+						String segline = row.get(0);
+						String[] splittok = segline.split("\\$\\|\\$");
+						empty_nodes.put(Integer.parseInt(splittok[1]), splittok[2]);
+						continue;
 					}
 
 					String word = check_index(form_index, "form_index", row, true);
@@ -116,6 +140,9 @@ public class SentenceReader implements Iterable<Sequence> {
 				number_+= tokens.size();
 
 				Sentence sentence = new Sentence(tokens);
+				sentence.setComments(comments);
+				sentence.setSegments(segments);
+				sentence.setEmptyNodes(empty_nodes);
 
 				return sentence;
 			}

--- a/marmot/src/marmot/util/LineIterator.java
+++ b/marmot/src/marmot/util/LineIterator.java
@@ -14,7 +14,8 @@ import java.util.NoSuchElementException;
 
 public class LineIterator implements Iterator<List<String>> {
 	
-	private final static String DefaultSeperator_ = "\\s+";
+	//private final static String DefaultSeperator_ = "\\s+";
+	private final static String DefaultSeperator_ = "\\t";
 	private BufferedReader reader_;
 	private String seperator_;
 	
@@ -63,7 +64,26 @@ public class LineIterator implements Iterator<List<String>> {
 		
 		try {
 			String line = reader_.readLine();
+			if (line.length() > 1 && line.charAt(0) == '#') { 
+				//System.out.println(line);
+				ArrayList<String> list = new ArrayList<String>(1);
+				list.add(line);
+				return list;
+			}
 			String[] tokens = line.split(seperator_);
+			if(tokens[0].contains(".")) {
+				ArrayList<String> list = new ArrayList<String>(1);
+				String[] idxTok = tokens[0].split(".");
+				list.add("$|$" + idxTok[0] + "$|$" + line);
+				list.add(line);
+				return list;
+			} else if(tokens[0].contains("-")) {
+				String[] idxTok = tokens[0].split("-");
+				ArrayList<String> list = new ArrayList<String>(1);
+				list.add("|$|" + idxTok[0] + "|$|" + line);
+				list.add(line);
+				return list;
+			}
 			ArrayList<String> list = new ArrayList<String>(tokens.length);
 			for (int i=0;i<tokens.length;i++){
 				if (!tokens[i].isEmpty()){


### PR DESCRIPTION
This patch allows for using the command line option `--conllu-format "true"` to output in CoNLL-U format[1], preserving comments, segments and empty nodes. 

It also allows for training data to be in CoNLL-U format, regardless of output format. 

It should provide the same output as `udpipe --tag`

On the TODO list is allowing input like:

```
# sent_id = es-dev-001-s15
# text = Tan solo Lemke puede retirar la maldición, y Billy trata de persuadir al anciano de que la retire.
1	Tan	_	_	_	_	_	_	_	_
2	solo	_	_	_	_	_	_	_	_
3	Lemke	_	_	_	_	_	_	_	_
4	puede	_	_	_	_	_	_	_	_
5	retirar	_	_	_	_	_	_	_	_
6	la	_	_	_	_	_	_	_	_
7	maldición	_	_	_	_	_	_	_	_
8	,	_	_	_	_	_	_	_	_
9	y	_	_	_	_	_	_	_	_
10	Billy	_	_	_	_	_	_	_	_
11	trata	_	_	_	_	_	_	_	_
12	de	_	_	_	_	_	_	_	_
13	persuadir	_	_	_	_	_	_	_	_
14-15	al	_	_	_	_	_	_	_	_
14	a	_	_	_	_	_	_	_	_
15	el	_	_	_	_	_	_	_	_
16	anciano	_	_	_	_	_	_	_	_
17	de	_	_	_	_	_	_	_	_
18	que	_	_	_	_	_	_	_	_
19	la	_	_	_	_	_	_	_	_
20	retire	_	_	_	_	_	_	_	_
21	.	_	_	_	_	_	_	_	_
```

This fixes issue #6 

1. http://universaldependencies.org/format.html